### PR TITLE
Dépendances Myqsl + Version 2.9 + problème DNS/NAT

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,9 +21,13 @@ fun_releases = {
     :ref =>"fun/release-2.7",
     :name => "named-release/birch.rc1", :box => "birch-devstack-rc1", :file => "20150203-birch-devstack-rc1.box"
   },
+  "2.9" => {
+    :ref =>"fun/release-2.9",
+    :name => "named-release/birch", :box => "birch-devstack", :file => "20150224-birch-devstack.box"
+  },
   "master" => {
-    :ref =>"fun/release-2.7",
-    :name => "named-release/birch.rc1", :box => "birch-devstack-rc1", :file => "20150203-birch-devstack-rc1.box"
+    :ref =>"fun/release-2.9",
+    :name => "named-release/birch", :box => "birch-devstack", :file => "20150224-birch-devstack.box"
   }
 }
 fun_release = (ENV["FUN_RELEASE"] or "master")

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -80,6 +80,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # Allow DNS to work for Ubuntu 12.10 host
     # http://askubuntu.com/questions/238040/how-do-i-fix-name-service-for-vagrant-client
     vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+    vb.customize ["modifyvm", :id, "--natdnsproxy1", "off"]
   end
 
   # Use vagrant-vbguest plugin to make sure Guest Additions are in sync

--- a/fun-devstack.yml
+++ b/fun-devstack.yml
@@ -20,6 +20,10 @@
       apt: name=google-chrome-stable state=absent
     - name: Uninstall firefox
       apt: name=firefox state=absent
+    - name: Uninstall myssql 5.6
+      apt: name=mysql-server-5.6 state=absent purge=yes
+    - name: Install myssql-common (5.5)
+      apt: name=mysql-common=5.5.41-0ubuntu0.12.04.1 state=present
     - name: Install mysql-client-5.5
       apt: name=mysql-client-5.5 state=present
     - name: Make sure no flag file prevents mysql-5.5 install


### PR DESCRIPTION
Le soucis du NAT est pas forcément résolu avec ce setting. Le seul truc qui marche vraiment est de changer en 8.8.8.8 chez moi. Pas la peine de se prendre la tête si c'est juste quelque chose de mal configuré chez moi. Au cas où....
