### PR TITLE
Fixes for Ansible 2.0

### DIFF
--- a/releases/upgrade.yml
+++ b/releases/upgrade.yml
@@ -3,8 +3,8 @@
 - name: Upgrade FUN development stack
   hosts: all
   remote_user: vagrant
-  sudo: yes
-  sudo_user: edxapp
+  become: yes
+  become_user: edxapp
   vars:
     fun_release: "dev"
     openedx_fun_release: "dev"

--- a/releases/upgrade.yml
+++ b/releases/upgrade.yml
@@ -49,25 +49,25 @@
       args:
         executable: /bin/bash
         chdir: "{{ edxapp_home}}/edx-platform"
-      environment: env
+      environment: "{{ env }}"
     - name: Generate lms assets
       shell: "{{ virtualenv }}/bin/fun lms.dev assets"
       args:
         chdir: "{{ edxapp_home}}/edx-platform"
-      environment: env
+      environment: "{{ env }}"
     - name: Generate cms assets
       shell: "{{ virtualenv }}/bin/fun cms.dev assets"
       args:
         chdir: "{{ edxapp_home}}/edx-platform"
-      environment: env
+      environment: "{{ env }}"
 
     - name: Migrate lms
       shell: "{{ virtualenv }}/bin/fun lms.dev migrate"
       args:
           chdir: "{{ edxapp_home }}/edx-platform"
-      environment: env
+      environment: "{{ env }}"
     - name: Migrate cms
       shell: "{{ virtualenv }}/bin/fun cms.dev migrate"
       args:
           chdir: "{{ edxapp_home }}/edx-platform"
-      environment: env
+      environment: "{{ env }}"


### PR DESCRIPTION
Fixes two issues when running `vagrant provision` using ansible 2.0:

* Error:
    ```
    TASK [Update requirements] *****************************************************
    [DEPRECATION WARNING]: Using bare variables for environment is deprecated.
    Update your playbooks so that the environment value uses the full variable syntax ('{{foo}}'). This feature will be removed in a future release.
    Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
    fatal: [default]: FAILED! => {"failed": true, "msg": "ERROR! environment must be a dictionary, received env (<class 'ansible.parsing.yaml.objects.AnsibleUnicode'>)"}
    ```
    dc57217 fixes the issue as directed by the deprecation warning, by quoting `"{{ env }}"`
* Warning:
    ```
    [DEPRECATION WARNING]: Instead of sudo/sudo_user, use become/become_user and make sure become_method is 'sudo' (default). This feature will be removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
   ```
   316448d fixes this issue as directed by the warning.


**Testing instructions**

1. On your local (host) machine, install `ansible >= 2.0 <= 2.3`.
1. From the `releases` dir, run `vagrant up --provision` to provision a new FUN VM, or `vagrant provision` to re-provision an existing VM.
1. Ensure that no deprecation warnings are shown, and the requirements, asset generation, and migration steps complete successfully.

**Reviewers**
* [x] @itsjeyd

CC @julAtWork 